### PR TITLE
fix(resolv): implements MAXNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ use the `rbusted` script.
 History
 =======
 
+###0.3.3 (xxx) Bugfixes
+
+- Fix: the MAXNS (3) was not honoured, so more than 3 nameservers would be parsed
+  from the `resolv.conf` file. Fixes [Kong issue #2290](https://github.com/Mashape/kong/issues/2290).
+
 ###0.3.2 (6-Mar-2017) Bugfixes
 
 - Fix: Cleanup disabled addresses but did not delete them, causing errors when

--- a/spec/utils_spec.lua
+++ b/spec/utils_spec.lua
@@ -135,6 +135,7 @@ domain myservice.com
 nameserver 8.8.8.8 
 nameserver 8.8.4.4 ; and a comment here
 nameserver 8.8.8.8:1234 ; this one has a port number (limited systems support this)
+nameserver 1.2.3.4 ; this one is 4th, so should be ignored
 
 # search is commented out, test below for a mutually exclusive one
 #search domaina.com domainb.com

--- a/src/resty/dns/utils.lua
+++ b/src/resty/dns/utils.lua
@@ -35,6 +35,10 @@ _M.DEFAULT_HOSTS = _DEFAULT_HOSTS
 -- @field DEFAULT_RESOLV_CONF Defaults to `/etc/resolv.conf`
 _M.DEFAULT_RESOLV_CONF = _DEFAULT_RESOLV_CONF
 
+--- Maximum number of nameservers to parse from the `resolv.conf` file
+-- @field MAXNS Defaults to 3
+_M.MAXNS = 3
+
 --- Parsing configuration files and variables
 -- @section parsing
 
@@ -144,7 +148,9 @@ _M.parseResolvConf = function(filename)
       local option, details = data:match("^%s*(%a+)%s+(.-)%s*$")
       if option == "nameserver" then
         result.nameserver = result.nameserver or {}
-        tinsert(result.nameserver, details:lower())
+        if #result.nameserver < _M.MAXNS then
+          tinsert(result.nameserver, details:lower())
+        end
       elseif option == "domain" then
         result.search = nil  -- mutually exclusive, last one wins
         result.domain = details:lower()


### PR DESCRIPTION
implements the MAXNS setting to parse only the max number of nameservers
from resolv.conf instead of all of them