### PR TITLE
feat(client) implements `search` and `ndots` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,21 @@ use the `rbusted` script.
 History
 =======
 
+### unreleased (xx-xxx-2017)
+
+- Removed: BREAKING! stdError function removed.
+- Added: implemented the `search` and `ndots` options.
+- Change: `resolve` no longer returns empty results or dns errors as a table
+  but as lua errors (`nil + error`).
+- Change: `toip()` and `resolve()` have an extra result; history. A table with
+  the list of tried names/types/results.
+- Fix: timeout and retrans options from `resolv.conf` were ignored by the
+  `client` module.
+
 ### 0.4.1 (21-Apr-2017) Bugfix
 
-- fix: cname record caching causing excessive dns queries
-  See [Kong issue #2303](https://github.com/Mashape/kong/issues/2303)
+- Fix: cname record caching causing excessive dns queries,
+  see [Kong issue #2303](https://github.com/Mashape/kong/issues/2303).
 
 ### 0.4.0 (30-Mar-2017) Bugfixes
 

--- a/spec/utils_spec.lua
+++ b/spec/utils_spec.lua
@@ -187,6 +187,26 @@ search domaina.com domainb.com
     assert.is.same({ "domaina.com", "domainb.com" }, resolv.search)
   end)
 
+  it("tests parsing 'resolv.conf' with max search entries MAXSEARCH", function()
+    local file = splitlines(
+    [[
+
+search domain1.com domain2.com domain3.com domain4.com domain5.com domain6.com domain7.com
+
+]])
+    local resolv, err = dnsutils.parseResolvConf(file)
+    assert.is.Nil(err)
+    assert.is.Nil(resolv.domain)
+    assert.is.same({
+        "domain1.com", 
+        "domain2.com",
+        "domain3.com", 
+        "domain4.com",
+        "domain5.com", 
+        "domain6.com",
+      }, resolv.search)
+  end)
+
   it("tests parsing 'resolv.conf' with environment variables", function()
     local file = splitlines(
     [[# this is just a comment line

--- a/src/resty/dns/balancer.lua
+++ b/src/resty/dns/balancer.lua
@@ -288,7 +288,7 @@ function objHost:queryDns(cacheOnly)
   -- yield (cosockets in the dns lib). So once that is done, we're 'atomic'
   -- again, and we shouldn't have any nasty race conditions
   local dns = self.balancer.dns
-  local newQuery, err = dns.stdError(dns.resolve(self.hostname, nil, cacheOnly))
+  local newQuery, err = dns.resolve(self.hostname, nil, cacheOnly)
 
   local oldQuery = self.lastQuery or {}
   local oldSorted = self.lastSorted or {}

--- a/src/resty/dns/utils.lua
+++ b/src/resty/dns/utils.lua
@@ -134,7 +134,8 @@ end
 -- will be ignored. Might return `nil + error` if the file cannot be read.
 -- @param filename (optional) File to parse (defaults to `'/etc/resolv.conf'` if 
 -- omitted) or a table with the file contents in lines.
--- @return a table with fields `nameserver` (table), `domain` (string), `search` (table), `sortlist` (table) and `options` (table)
+-- @return a table with fields `nameserver` (table), `domain` (string), `search` (table),
+-- `sortlist` (table) and `options` (table)
 -- @see applyEnv
 _M.parseResolvConf = function(filename)
   local lines

--- a/src/resty/dns/utils.lua
+++ b/src/resty/dns/utils.lua
@@ -39,6 +39,10 @@ _M.DEFAULT_RESOLV_CONF = _DEFAULT_RESOLV_CONF
 -- @field MAXNS Defaults to 3
 _M.MAXNS = 3
 
+--- Maximum number of entries to parse from `search` parameter in the `resolv.conf` file
+-- @field MAXSEARCH Defaults to 6
+_M.MAXSEARCH = 6
+
 --- Parsing configuration files and variables
 -- @section parsing
 
@@ -159,7 +163,9 @@ _M.parseResolvConf = function(filename)
         local search = {}
         result.search = search
         for host in details:gmatch("%S+") do
-          tinsert(search, host:lower())
+          if #search < _M.MAXSEARCH then
+            tinsert(search, host:lower())
+          end
         end
       elseif option == "sortlist" then
         local list = {}


### PR DESCRIPTION
Also deprecates the `stdError` function. Generates an extra return
value for toip() and resolve() to track history of searches.

fixes #6 