### PR TITLE
fix(balancer) named SRV entries return hostname properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ History
 
 ### 0.6.x (xx-xxx-2017) Fixes and refactor
 
+- Fix: balancer not returning hostname for named SRV entries. See
+  [issue #17](https://github.com/Mashape/lua-resty-dns-client/issues/17)
 - Fix: fix an occasionally failing test
 - Refactor: remove metadata from the records, instead store it in its own cache
 

--- a/spec/balancer_spec.lua
+++ b/spec/balancer_spec.lua
@@ -555,6 +555,28 @@ describe("Loadbalancer", function()
   end)
 
   describe("getting targets", function()
+    it("gets an IP address, port and hostname for named SRV entries", function()
+      -- this case is special because it does a last-minute `toip` call and hence
+      -- uses a different code branch
+      -- See issue #17
+      dnsA({ 
+        { name = "mashape.com", address = "1.2.3.4" },
+      })
+      dnsSRV({ 
+        { name = "gelato.io", target = "mashape.com", port = 8001 },
+      })
+      local b = check_balancer(balancer.new { 
+        hosts = { 
+          {name = "gelato.io", port = 123, weight = 100},
+        },
+        dns = client,
+      })
+      -- run down the wheel twice
+      local addr, port, host = b:getPeer()
+      assert.equal("1.2.3.4", addr)
+      assert.equal(8001, port)
+      assert.equal("gelato.io", host)
+    end)
     it("gets an IP address and port number round-robin", function()
       dnsA({ 
         { name = "mashape.com", address = "1.2.3.4" },

--- a/src/resty/dns/balancer.lua
+++ b/src/resty/dns/balancer.lua
@@ -105,7 +105,9 @@ function objAddr:getPeer(cacheOnly)
   if self.ipType == "name" then
     -- SRV type record with a named target
     local ip, port = dns.toip(self.ip, self.port, cacheOnly)
-    return ip, port, self.host.name
+    -- TODO: which is the proper name to return in this case?
+    -- `self.host.hostname`? or the named SRV entry: `self.ip`?
+    return ip, port, self.host.hostname
   else
     -- just an IP address
     return self.ip, self.port, self.host.hostname


### PR DESCRIPTION
Named entries in an SRV record would not return the hostname
properly, but always 'nil'.

Fixes #17